### PR TITLE
Use {static} instead of {filename}

### DIFF
--- a/posts/2013/a-beginners-guide-to-os-encryption-dual.md
+++ b/posts/2013/a-beginners-guide-to-os-encryption-dual.md
@@ -7,7 +7,7 @@ Slug: a-beginners-guide-to-os-encryption-dual
 Summary: How to encrypt Windows and Ubuntu in a dual boot system.
 Alias: /2013/09/a-beginners-guide-to-os-encryption-dual.html
 
-<img class="article-image" src="{filename}/images/2013/Padlock_and_key.jpg" alt="A padlock with a key." width="320">
+<img class="article-image" src="{static}/images/2013/Padlock_and_key.jpg" alt="A padlock with a key." width="320">
 
 The beginner in the title of this post may or may not refer to you. It
 certainly describes me. Since I was about to setup a new PC, I decided
@@ -72,7 +72,7 @@ please email or [let me know via Twitter](https://twitter.com/StevenMaude).
 
 ## Approach 2: Encrypt Windows 7 Enterprise/Ultimate with Bitlocker; encrypt Ubuntu with LUKS
 
-<img class="article-image" src="{filename}/images/2013/Bitlocker.png" alt="Screengrab of Bitlocker's user interface in Windows 7.">
+<img class="article-image" src="{static}/images/2013/Bitlocker.png" alt="Screengrab of Bitlocker's user interface in Windows 7.">
 
 The first issue here is that the only versions of Windows 7 that support
 Bitlocker are Enterprise and Ultimate. If you have Windows 7 Pro, you're
@@ -97,7 +97,7 @@ considering this option.
 
 ## Approach 3: Encrypt Windows 7 (any version) with TrueCrypt; encrypt Ubuntu with LUKS
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt.png" alt="TrueCrypt program window showing options to create a new encrypted volume.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt.png" alt="TrueCrypt program window showing options to create a new encrypted volume.">
 
 !!! article-edit ""
     Edit October 2015: There are vulnerabilities in the Windows

--- a/posts/2013/firefox-21-annoyances.md
+++ b/posts/2013/firefox-21-annoyances.md
@@ -44,7 +44,7 @@ My initial thought was to check the list of MIME types (Options \>
 Applications) to see if anything had changed. No, it still looked just
 as it did before:
 
-<img class="article-image" src="{filename}/images/2013/Firefox_MIME_types.png" alt="Firefox MIME types">
+<img class="article-image" src="{static}/images/2013/Firefox_MIME_types.png" alt="Firefox MIME types">
 
 The about:config option to restore the original behaviour is to set
 [media.windows-media-foundation.enabled to

--- a/posts/2013/how-to-access-github-over-ssh-on-ubuntu.md
+++ b/posts/2013/how-to-access-github-over-ssh-on-ubuntu.md
@@ -7,7 +7,7 @@ Slug: how-to-access-github-over-ssh-on-ubuntu
 Summary: How to use GitHub over SSH in Ubuntu, and forward SSH keys to other shell accounts.
 Alias: /2013/09/how-to-access-github-over-ssh-on-ubuntu.html
 
-<img class="article-image" src="{filename}/images/2013/GitHub_logo.png" alt="GitHub logo">
+<img class="article-image" src="{static}/images/2013/GitHub_logo.png" alt="GitHub logo">
 
 [Since starting working at
 ScraperWiki](http://blog.scraperwiki.com/2013/09/02/hi-im-steve/), I've
@@ -42,7 +42,7 @@ it.](https://help.github.com/articles/generating-ssh-keys)
     image; where it says clone with HTTPS, SSH..., click on SSH).
 
     <div class="break-out-of-list">
-      <img class="article-image" src="{filename}/images/2013/GitHub_clone.png" alt="GitHub sidebar showing the position of the clone URL display.">
+      <img class="article-image" src="{static}/images/2013/GitHub_clone.png" alt="GitHub sidebar showing the position of the clone URL display.">
     </div>
 
     Now, the first time you try to perform some action on GitHub via ssh

--- a/posts/2013/how-to-secure-your-storage-and-backup.md
+++ b/posts/2013/how-to-secure-your-storage-and-backup.md
@@ -18,7 +18,7 @@ spent](http://www.stevenmaude.co.uk/2013/09/a-beginners-guide-to-os-encryption-d
 encrypting operating system drives, it's a relief that encrypting
 non-system drives is far, far simpler.
 
-<img class="article-image" src="{filename}/images/2013/Bitlocker_context_menu.png" alt="Bitlocker drive context menu.">
+<img class="article-image" src="{static}/images/2013/Bitlocker_context_menu.png" alt="Bitlocker drive context menu.">
 
 ## Bitlocker
 
@@ -29,7 +29,7 @@ self-explanatory instructions.
 Right clicking an external drive in Explorer brings up the Bitlocker
 option (as shown to the right).
 
-<img class="article-image" src="{filename}/images/2013/Bitlocker_unlock_menu.png" alt="Bitlocker drive unlock menu.">
+<img class="article-image" src="{static}/images/2013/Bitlocker_unlock_menu.png" alt="Bitlocker drive unlock menu.">
 
 Next, you then choose a password to unlock the drive, then save or print
 a recovery key in case you forget your password. All that's left is to
@@ -76,7 +76,7 @@ freely available, and has good cross-platform support, perhaps making it
 a better choice. Go to Volumes > Create New Volume... and you'll see
 this menu:
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_menu.png" alt="The TrueCrypt volume creation wizard.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_menu.png" alt="The TrueCrypt volume creation wizard.">
 
 You can optionally use an encrypted drive container, which is a virtual
 disk in a file, should you want to store unencrypted files on your drive
@@ -84,17 +84,17 @@ alongside encrypted ones. My preference is just to encrypt the entire
 thing, so there's no risk of me inadvertently storing something
 containing personal information in the unencrypted part.
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_volume_type.png" alt="Specifying TrueCrypt volume type.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_volume_type.png" alt="Specifying TrueCrypt volume type.">
 
 Here, TrueCrypt asks if you want to hide the volume. In my case, a
 standard volume is sufficient.
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_volume_location.png" alt="Specifying TrueCrypt volume location.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_volume_location.png" alt="Specifying TrueCrypt volume location.">
 
 Click Select Device, choose the drive you want to encrypt and click
 Next.
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_encryption_options.png" alt="The TrueCrypt volume creation window.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_encryption_options.png" alt="The TrueCrypt volume creation window.">
 
 If you've nothing on the drive already, you can format it. Otherwise,
 you'll have to encrypt it in place which will take longer. On the next
@@ -102,13 +102,13 @@ page after this, it allows you to specify the encryption algorithms, I
 leave these as default. It will then tell you the volume size so that
 you can double check you've specified the correct drive.
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_format_options.png" alt="The TrueCrypt volume format window.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_format_options.png" alt="The TrueCrypt volume format window.">
 
 After that, you enter a password, choose what kind of filesystem (e.g.
 FAT or NTFS) you want for the drive, move the mouse in the TrueCrypt for
 a while to generate random data and click Format.
 
-<img class="article-image" src="{filename}/images/2013/TrueCrypt_drive_menu.png" alt="The TrueCrypt window showing a list of drives and drive letters to mount.">
+<img class="article-image" src="{static}/images/2013/TrueCrypt_drive_menu.png" alt="The TrueCrypt window showing a list of drives and drive letters to mount.">
 
 To mount the drive, you launch TrueCrypt, choose Select Device, select
 your TrueCrypt drive, select an empty drive letter and choose Mount.

--- a/posts/2013/job-advertisements.md
+++ b/posts/2013/job-advertisements.md
@@ -17,7 +17,7 @@ Usually, job specifications are pretty much just as you would expect
 from the job title. I'm not entirely sure whether the highlighted point
 in this vacancy was really necessary though:
 
-<img class="article-image" src="{filename}/images/2013/Job_specification.png" alt="A job vacancy posting.">
+<img class="article-image" src="{static}/images/2013/Job_specification.png" alt="A job vacancy posting.">
 
 "So, you're a maths expert. That's great for this role! Oh, one final
 thing, if we happen to have a cake day at the office, are you going to

--- a/posts/2013/leaky-phone-apps.md
+++ b/posts/2013/leaky-phone-apps.md
@@ -11,7 +11,7 @@ My phone doesn't have a huge number of third party apps installed, but
 saw this chart today and it's a little worrying nonetheless:
 
 <figure class="article-figure">
-  <img src="{filename}/images/2013/Free_apps_chart.jpg" alt="Chart showing a substantial proportion of free apps collect data such as location.">
+  <img src="{static}/images/2013/Free_apps_chart.jpg" alt="Chart showing a substantial proportion of free apps collect data such as location.">
   <figcaption>Chart courtesy of <a href="http://www.statista.com/topics/876/android/chart/1228/free-apps-are-hungry-for-user-data/">Statista</a>.</figcaption>
 </figure>
 

--- a/posts/2013/things-ive-learned-from-building-and.md
+++ b/posts/2013/things-ive-learned-from-building-and.md
@@ -7,7 +7,7 @@ Slug: things-ive-learned-from-building-and
 Summary: Things I've learned from building (and rebuilding) a PC.
 Alias: /2013/12/things-ive-learned-from-building-and.html
 
-<img class="article-image" src="{filename}/images/2014/PC.jpg" alt="Image of an assembled PC." width="400">
+<img class="article-image" src="{static}/images/2014/PC.jpg" alt="Image of an assembled PC." width="400">
 
 Delving into the inside of PCs isn't that new to me, I've swapped in and
 out pretty much every part at some point individually. But, building a
@@ -76,7 +76,7 @@ in huge packs very cheaply (I paid a couple of pounds for a hundred).
 4\. **I didn't understand why there were so many complaints about Intel's
 push pin cooler design until I had to install it the second time.**
 
-<img class="article-image" src="{filename}/images/2014/Cooler_push_pin.jpg" alt="Close-up image of an Intel heatsink showing the push pin that holds the heatsink in place in a motherboard." width="300">
+<img class="article-image" src="{static}/images/2014/Cooler_push_pin.jpg" alt="Close-up image of an Intel heatsink showing the push pin that holds the heatsink in place in a motherboard." width="300">
 
 You put the pins of the cooler through the motherboard then click them
 in place to open out the pins and lock them there. Sounds easy, until

--- a/posts/2013/uses-for-a-raspberry-pi-part-1.md
+++ b/posts/2013/uses-for-a-raspberry-pi-part-1.md
@@ -7,7 +7,7 @@ Slug: uses-for-a-raspberry-pi-part-1
 Summary: A few simple, but useful, applications for a Raspberry Pi, including a wireless adapter and AirPrint server.
 Alias: /2013/07/uses-for-a-raspberry-pi-part-1.html
 
-<img class="article-image" src="{filename}/images/2013/Raspberry_Pi.jpg" alt="A powered on Raspberry Pi.">
+<img class="article-image" src="{static}/images/2013/Raspberry_Pi.jpg" alt="A powered on Raspberry Pi.">
 
 <blockquote>
   <p>Don’t buy one and put it in the cupboard; buy one and do an
@@ -92,7 +92,7 @@ port was going unused. It's relatively straightforward to configure the
 Pi to enable a device connected to it by Ethernet to use the Pi's wifi
 connection to access the network
 
-<img class="article-image" src="{filename}/images/2013/Wifi_dongle.jpg" alt="Wifi adapter for the Pi.">
+<img class="article-image" src="{static}/images/2013/Wifi_dongle.jpg" alt="Wifi adapter for the Pi.">
 
 Wifi is a common feature of networked devices these days, but the Xbox
 360 is an exception to this rule. Earlier this year, I explained in [a

--- a/posts/2013/uses-for-a-raspberry-pi-part-2.md
+++ b/posts/2013/uses-for-a-raspberry-pi-part-2.md
@@ -8,7 +8,7 @@ Summary: Running the Raspberry Pi as a file and media server, and as a PVR with 
 Alias: /2013/07/uses-for-a-raspberry-pi-part-2.html
 
 
-<img class="article-image" src="{filename}/images/2013/Raspberry_Pi.jpg" alt="A Raspberry Pi working hard!">
+<img class="article-image" src="{static}/images/2013/Raspberry_Pi.jpg" alt="A Raspberry Pi working hard!">
 
 In my [last
 post](http://www.stevenmaude.co.uk/2013/07/uses-for-a-raspberry-pi-part-1),
@@ -169,7 +169,7 @@ reasons.
 
 ### Scheduling the PVR to run
 
-<img class="article-image" src="{filename}/images/2013/get_iplayer_crontab.png" alt="Crontab with get_iplayer scheduled.">
+<img class="article-image" src="{static}/images/2013/get_iplayer_crontab.png" alt="Crontab with get_iplayer scheduled.">
 
 However, it is more convenient to run the PVR regularly rather than have
 to run it manually. You can add the command to run the PVR to the [cron

--- a/posts/2014/arduous-lessons-in-python-why-main-is.md
+++ b/posts/2014/arduous-lessons-in-python-why-main-is.md
@@ -7,7 +7,7 @@ Slug: arduous-lessons-in-python-why-main-is
 Summary: Why if `__name__ == '__main__'` is a sensible check in code you're reusing.
 Alias: /2014/07/arduous-lessons-in-python-why-main-is.html
 
-<img class="article-image" src="{filename}/images/2014/python_logo.png" alt="The Python logo.">
+<img class="article-image" src="{static}/images/2014/python_logo.png" alt="The Python logo.">
 
 An ordinary afternoon and I'd wanted to work on some code locally on my
 machine. I knew the tests previously ran without any issue. So, after

--- a/posts/2014/beatmatching-five-reasons-why-digital.md
+++ b/posts/2014/beatmatching-five-reasons-why-digital.md
@@ -12,7 +12,7 @@ Alias: /2014/01/beatmatching-five-reasons-why-digital.html
 
 ## DJ software: complete with the kitsch in sync
 
-<img class="article-image" src="{filename}/images/2014/sync.jpg" alt="Sync button from a Vestax VCI-100." width="400">
+<img class="article-image" src="{static}/images/2014/sync.jpg" alt="Sync button from a Vestax VCI-100." width="400">
 
 There's a view — one I guess is primarily propagated by people who were DJing
 long before the likes of Traktor and Serato[^1] came
@@ -86,7 +86,7 @@ learning to do this myself, I shouldn't use any of these tools ." But,
 when you're learning to manually beatmatch, **these features are still
 really useful**. So what do we have?
 
-<img class="article-image" src="{filename}/images/2014/Traktor_layout.png" alt="Traktor deck showing sync button, phase meter and grid options with a BPM counter.">
+<img class="article-image" src="{static}/images/2014/Traktor_layout.png" alt="Traktor deck showing sync button, phase meter and grid options with a BPM counter.">
 
 ### Phase meter
 
@@ -149,7 +149,7 @@ the live track; also useful in developing beatmatching skills.
 
 ### Recording
 
-<img class="article-image" src="{filename}/images/2014/Audio_recorder.png" alt="Traktor's audio recorder options.">
+<img class="article-image" src="{static}/images/2014/Audio_recorder.png" alt="Traktor's audio recorder options.">
 
 It's not always easy to judge how well your beatmatching is while you're
 actually doing it. Recording your practice and listening back to see how

--- a/posts/2014/book-review-data-science-for-business.md
+++ b/posts/2014/book-review-data-science-for-business.md
@@ -7,7 +7,7 @@ Slug: book-review-data-science-for-business
 Summary: A review of Foster Provost and Tom Fawcett's introductory data science book: "Data Science for Business".
 Alias: /2014/01/book-review-data-science-for-business.html
 
-<img class="article-image" src="{filename}/images/2014/Data_Science_for_Business.jpg" alt="Cover of &quot;Data Science for Business&quot; book." width="300">
+<img class="article-image" src="{static}/images/2014/Data_Science_for_Business.jpg" alt="Cover of &quot;Data Science for Business&quot; book." width="300">
 
 I recently read "Data Science for Business" by Foster Provost and Tom
 Fawcett for the upcoming [Data Science Book

--- a/posts/2014/chatting-about-data-science-careers.md
+++ b/posts/2014/chatting-about-data-science-careers.md
@@ -8,7 +8,7 @@ Alias: /2014/06/chatting-about-data-science-careers.html
 
 ## Visiting Cambridge
 
-<img class="article-image" src="{filename}/images/2014/Cambridge_1.jpg" alt="A photo of a street in Cambridge" width=300>
+<img class="article-image" src="{static}/images/2014/Cambridge_1.jpg" alt="A photo of a street in Cambridge" width=300>
 
 I visited Cambridge this week. Though I know Oxford fairly well, somehow
 I'd manage to avoid ever travelling to Cambridge before, so being in a
@@ -62,7 +62,7 @@ a disconnect between employers looking for well qualified PhDs and the
 candidates themselves. The jobs are there. The candidates are there.
 But, for whatever reason, they're missing each other.
 
-<img class="article-image" src="{filename}/images/2014/Cambridge_2.jpg" alt="Another photo taken in Cambridge.">
+<img class="article-image" src="{static}/images/2014/Cambridge_2.jpg" alt="Another photo taken in Cambridge.">
 
 From my experience as a researcher, I'd suggest a part of the problem is
 that PhDs and postdocs may be simply unaware of the range of

--- a/posts/2014/heartbleed-ill-communication.md
+++ b/posts/2014/heartbleed-ill-communication.md
@@ -7,7 +7,7 @@ Slug: heartbleed-ill-communication
 Summary: On the lack of communication of websites as to the impact of Heartbleed.
 Alias: /2014/05/heartbleed-ill-communication.html
 
-<img class="article-image" src="{filename}/images/2014/heartbleed.png" alt="The Heartbleed logo." width="400">
+<img class="article-image" src="{static}/images/2014/heartbleed.png" alt="The Heartbleed logo." width="400">
 
 Even if you're not particularly into technology, you probably wouldn't
 have escaped hearing about Heartbleed last month.

--- a/posts/2014/making-aero-theme-settings-stick-in.md
+++ b/posts/2014/making-aero-theme-settings-stick-in.md
@@ -20,14 +20,14 @@ Computer and click Properties, you can access the "Advanced system
 settings" which lets you access the Aero theme settings to disable these
 features.
 
-<img class="article-image" src="{filename}/images/2014/SystemPropertiesPerformance2.png" alt="The Windows System Properties and Performance Options (visual effects) menus.">
+<img class="article-image" src="{static}/images/2014/SystemPropertiesPerformance2.png" alt="The Windows System Properties and Performance Options (visual effects) menus.">
 
 However, on changing these settings, you might find that, although they
 work, they don't actually stick. When you next log on, the settings have
 been restored to the defaults. It may be an issue with running accounts
 as standard users, rather than administrators.
 
-<img class="article-image" src="{filename}/images/2014/SystemPropertiesPerformance.png" alt="The Windows Start Menu with SystemPropertiesPerformance ty ed to display the settings menu that lets users change the Aero theme settings.">
+<img class="article-image" src="{static}/images/2014/SystemPropertiesPerformance.png" alt="The Windows Start Menu with SystemPropertiesPerformance ty ed to display the settings menu that lets users change the Aero theme settings.">
 
 To ensure the settings are kept, access this settings panel instead by
 typing

--- a/posts/2014/rockbox-ipod-nano-2g-and-inverted-audio.md
+++ b/posts/2014/rockbox-ipod-nano-2g-and-inverted-audio.md
@@ -7,7 +7,7 @@ Slug: rockbox-ipod-nano-2g-and-inverted-audio
 Summary: Discovering an (old) bug in Rockbox swapping audio channels on iPod Nano 2G.
 Alias: /2014/04/rockbox-ipod-nano-2g-and-inverted-audio.html
 
-<img class="article-image" src="{filename}/images/2014/rockbox3540.jpg" alt="The Rockbox logo.">
+<img class="article-image" src="{static}/images/2014/rockbox3540.jpg" alt="The Rockbox logo.">
 
 I do a lot of listening to music and podcasts with a trusty old second
 generation iPod Nano running [Rockbox](http://www.rockbox.org). What

--- a/posts/2014/taking-control-of-chromium-and-chrome.md
+++ b/posts/2014/taking-control-of-chromium-and-chrome.md
@@ -164,7 +164,7 @@ By virtue of what HTTP Switchboard aims to do — give you full control of
 what is allowed by your browser — this makes its user interface slightly
 more complex, which I'll soon get onto.
 
-<img class="article-image" src="{filename}/images/2014/ublock.png" alt="The ublock enable/disable icon." width="174">
+<img class="article-image" src="{static}/images/2014/ublock.png" alt="The ublock enable/disable icon." width="174">
 
 Stripping out this sophistication seems like a smart move, since
 ublock's incredibly easy to use. Really, it requires the same amount of
@@ -199,7 +199,7 @@ site to run scripts or store cookies. These have a text explanation of
 what the option does.
 
 <figure class="article-figure">
-  <img src="{filename}/images/2014/Firefox_menus.png" alt="Examples of NoScript, CookieMonster and RequestPolicy permission menus.">
+  <img src="{static}/images/2014/Firefox_menus.png" alt="Examples of NoScript, CookieMonster and RequestPolicy permission menus.">
   <figcaption>From left to right, examples of NoScript, CookieMonster and RequestPolicy permission menus when accessing Google Books.</figcaption>
 </figure>
 
@@ -214,7 +214,7 @@ Each site is represented as a row, and each type of content is shown as
 a column.
 
 <figure class="article-figure">
-  <img src="{filename}/images/2014/HTTP_Switchboard.png" alt="Example of HTTP Switchboard's table interface.">
+  <img src="{static}/images/2014/HTTP_Switchboard.png" alt="Example of HTTP Switchboard's table interface.">
   <figcaption>Example of HTTP Switchboard's interface when accessing Google Books.</figcaption>
 </figure>
 

--- a/posts/2014/us-pycon-2014-talks.md
+++ b/posts/2014/us-pycon-2014-talks.md
@@ -7,7 +7,7 @@ Slug: us-pycon-2014-talks
 Summary: Rundown of some great US PyCon talks I recently watched.
 Alias: /2014/04/us-pycon-2014-talks.html
 
-<img class="article-image" src="{filename}/images/2014/python_logo.png" alt="The Python logo.">
+<img class="article-image" src="{static}/images/2014/python_logo.png" alt="The Python logo.">
 
 The US PyCon took place over the last week or so and there are a huge
 selection of videos of the talks up at

--- a/posts/2016/github-human-detection.md
+++ b/posts/2016/github-human-detection.md
@@ -15,7 +15,7 @@ Summary: GitHub hiding my profile reminds me there are no guarantees of your pre
 
 I logged into GitHub this week and saw an unusual message:
 
-<img class="article-image" src="{filename}/images/2016/GitHub_not_human.png" alt="The GitHub message prompting me that I'm possibly not human.">
+<img class="article-image" src="{static}/images/2016/GitHub_not_human.png" alt="The GitHub message prompting me that I'm possibly not human.">
 
 > One of our mostly harmless robots seems to think you are not a human.
 >


### PR DESCRIPTION
For linking static files.

Fixes warnings on blog build with Pelican 4.2.0:

```
WARNING: {filename} used for linking to static content…
Use {static} instead
```